### PR TITLE
Fix incorrect url when deploy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ function generate_post_list(locals) {
     var urls = [...locals.posts.toArray()]
         .filter(x => x.published)
         .map(x => {
+            const url = config.root + x.path
             return {
                 title: x.title,
-                url  : config.root + x.path
+                url  : url.startsWith('//') ? url.substr(1) : url
             };
         });
     return {


### PR DESCRIPTION
I got incorrect url when I using `hexo d`. They inserted this format of URL in my LeanCloud Counter Class:

![20201222_165510](https://user-images.githubusercontent.com/25103518/102870376-ea70f380-4477-11eb-9c73-c304d87f95da.png)

And `leancloud.memo`:

![20201222_165503](https://user-images.githubusercontent.com/25103518/102870645-45a2e600-4478-11eb-80dc-21dfb1cb5422.png)

But the request URL like it, `where` QueryString has only one slash `{"url":"/530.html"}` cause not working:

```
https://example.com/1.1/classes/Counter?where=%7B%22url%22%3A%22%2F530.html%22%7D
```

I fixed this problem, if this change has no side effects, merge it.


